### PR TITLE
ECDR-75 - updated to pass in the duration parameter to the cache.  Code ...

### DIFF
--- a/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/OpenSearchSource.java
+++ b/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/OpenSearchSource.java
@@ -241,8 +241,11 @@ public class OpenSearchSource extends AbstractCDRSource {
             cacheId = getId() + "-" + UUID.randomUUID();
             LOGGER.debug( "ConfigUpdate: Creating a cache with id [{}] for Metacard id lookups for source [{}] with an cache expiration time of [{}] minutes",
                     cacheId, getId(), minutes );
-            // ECDR-75 populate the cache porperties via config
-            metacardCache = cacheManager.createCacheInstance( cacheId, null );
+
+            Map<String, Object> cacheProps = new HashMap<String, Object>();
+            cacheProps.put( CacheManager.CACHE_EXPIRE_AFTER_MINUTES, minutes );
+
+            metacardCache = cacheManager.createCacheInstance( cacheId, cacheProps );
         }
     }
 


### PR DESCRIPTION
...was already in the cache to make use of the parameter if it existed so did not have to update it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/33)
<!-- Reviewable:end -->
