### PR TITLE
ECDR-93 - Altered some of the atom entry logic for setting security markings on atom entry when metadata is transformed

### DIFF
--- a/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AbstractAtomTransformer.java
+++ b/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AbstractAtomTransformer.java
@@ -81,7 +81,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
     private static final Logger LOGGER = LoggerFactory.getLogger( AbstractAtomTransformer.class );
     private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.dateTime();
 
-    private static final String FORMAT_KEY = "format";
+    
 
     private ActionProvider viewMetacardActionProvider = null;
     private ActionProvider resourceActionProvider = null;
@@ -154,12 +154,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
         feed.declareNS( AtomResponseConstants.CDRB_NAMESPACE, AtomResponseConstants.CDRB_NAMESPACE_PREFIX );
         feed.declareNS( AtomResponseConstants.CDRS_EXT_NAMESPACE, AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX );
 
-        if ( properties.get( FORMAT_KEY ) != null ) {
-            setFeedSecurity( feed, properties.get( FORMAT_KEY ).toString() );
-        } else {
-            LOGGER.debug( "No format was found for response, using default security markings." );
-            setFeedSecurity( feed, null );
-        }
+        
 
         feed.newId();
         setFeedTitle( feed, properties );
@@ -409,8 +404,6 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
 
         entry.declareNS( AtomResponseConstants.GEORSS_NAMESPACE, AtomResponseConstants.GEORSS_NAMESPACE_PREFIX );
         entry.declareNS( AtomResponseConstants.RELEVANCE_NAMESPACE, AtomResponseConstants.RELEVANCE_NAMESPACE_PREFIX );
-
-        setEntrySecurity( entry, metacard );
 
         entry.setId( metacard.getAtomId() );
         entry.setTitle( metacard.getTitle() );

--- a/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AtomTransformer.java
+++ b/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AtomTransformer.java
@@ -27,11 +27,17 @@ import net.di2e.ecdr.search.transform.atom.security.SecurityConfiguration;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Feed;
 import org.codice.ddf.configuration.impl.ConfigurationWatcherImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ddf.action.ActionProvider;
 import ddf.catalog.operation.SourceResponse;
 
 public class AtomTransformer extends AbstractAtomTransformer {
+    
+    private static final String FORMAT_KEY = "format";
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger( AtomTransformer.class );
 
     public AtomTransformer( ConfigurationWatcherImpl configWatcher, ActionProvider viewMetacardProvider, ActionProvider metadataProvider, ActionProvider resourceProvider,
             ActionProvider thumbnailProvider, MimeType thumbnailMime, MimeType viewMime, List<SecurityConfiguration> securityConfig ) {
@@ -40,10 +46,17 @@ public class AtomTransformer extends AbstractAtomTransformer {
 
     @Override
     public void addFeedElements( Feed feed, SourceResponse response, Map<String, Serializable> properties ) {
+        if ( properties.get( FORMAT_KEY ) != null ) {
+            setFeedSecurity( feed, properties.get( FORMAT_KEY ).toString() );
+        } else {
+            LOGGER.debug( "No format was found for response, using default security markings." );
+            setFeedSecurity( feed, null );
+        }
     }
 
     @Override
     public void addEntryElements( Entry entry, CDRMetacard metacard, Map<String, Serializable> properties ) {
+        setEntrySecurity( entry, metacard );
     }
 
 }


### PR DESCRIPTION
moved some of the logic around so the Entry Security Handler and Feed Security handlers get called in the abstract methods, and specifically for the Entry Security Handler, after the transform takes place (if there is one), so the security markings align with the transformed DDMS instead of the original DDMS

FYI @mrmateo 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/48)
<!-- Reviewable:end -->
