### PR TITLE
ECDR-116 updated the servlet dependency so it would deploy on DDF 2.4.1

### DIFF
--- a/api/cdr-api-auditor/pom.xml
+++ b/api/cdr-api-auditor/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
+            <artifactId>catalog-core-api</artifactId>
             <version>${ddf.catalog.version}</version>
         </dependency>
         <dependency>
@@ -53,6 +53,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
+                            javax.servlet.http;version="[2.5,4)",
                             *
                         </Import-Package>
                         <Export-Package>

--- a/endpoint/cdr-rest-broker-endpoint/pom.xml
+++ b/endpoint/cdr-rest-broker-endpoint/pom.xml
@@ -76,6 +76,7 @@
                             META-INF.cxf;version="[2.7.0, 4.0)";resolution:=optional,
                             META-INF.cxf.osgi;version="[2.7.0, 4.0)";resolution:=optional,
                             templates;resolution:=optional,
+                            javax.servlet.http;version="[2.5,4)",
                             *,
                         </Import-Package>
                         <Export-Package />

--- a/endpoint/cdr-rest-search-endpoint/pom.xml
+++ b/endpoint/cdr-rest-search-endpoint/pom.xml
@@ -71,6 +71,7 @@
                             META-INF.cxf;version="[2.7.0, 4.0)";resolution:=optional,
                             META-INF.cxf.osgi;version="[2.7.0, 4.0)";resolution:=optional,
                             templates;resolution:=optional,
+                            javax.servlet.http;version="[2.5,4)",
                             *,
                         </Import-Package>
                         <Export-Package />

--- a/libs/cdr-rest-search-commons/pom.xml
+++ b/libs/cdr-rest-search-commons/pom.xml
@@ -119,7 +119,8 @@
                         </Embed-Dependency>
                         <Import-Package>
                             !org.apache.commons.codec.*,
-                            *,
+                            javax.servlet.http;version="[2.5,4)",
+                            *
                         </Import-Package>
                         <Export-Package>
                             net.di2e.ecdr.commons.*,


### PR DESCRIPTION
@mrmateo FYI, just updated the servlet version range.  Made it wider, since we are really dependent on CXF and Jetty, and if those work, then our code should work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/56)
<!-- Reviewable:end -->
