### PR TITLE
ECDR-117 - updated the logic so that it would pull in the mapped name…

### DIFF
--- a/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AbstractAtomTransformer.java
+++ b/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AbstractAtomTransformer.java
@@ -501,7 +501,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
             if ( action != null && action.getUrl() != null ) {
                 String transformFormat = (String) properties.get( SearchConstants.METACARD_TRANSFORMER_NAME );
                 if ( StringUtils.isBlank( transformFormat ) ) {
-                    transformFormat = format == null ? CDR_ATOM_TRANSFORMER_ID : format;
+                    transformFormat = StringUtils.defaultIfBlank( format, CDR_ATOM_TRANSFORMER_ID );
                 }
                 entry.addLink( action.getUrl().toString() + "?transform=" + transformFormat, Link.REL_SELF, AtomResponseConstants.ATOM_MIME_TYPE, "View Atom Entry", null, -1 );
                 entry.addLink( action.getUrl().toString(), Link.REL_RELATED, "text/xml", action.getTitle(), null, -1 );

--- a/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AbstractAtomTransformer.java
+++ b/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AbstractAtomTransformer.java
@@ -15,22 +15,21 @@
  */
 package net.di2e.ecdr.search.transform.atom;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
-import ddf.action.Action;
-import ddf.action.ActionProvider;
-import ddf.catalog.data.BinaryContent;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.BinaryContentImpl;
-import ddf.catalog.operation.ProcessingDetails;
-import ddf.catalog.operation.QueryRequest;
-import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.operation.SourceResponse;
-import ddf.catalog.transform.CatalogTransformerException;
-import ddf.catalog.transform.MetacardTransformer;
-import ddf.catalog.transform.QueryResponseTransformer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
+import javax.xml.namespace.QName;
+
 import net.di2e.ecdr.commons.CDRMetacard;
 import net.di2e.ecdr.commons.constants.BrokerConstants;
 import net.di2e.ecdr.commons.constants.SearchConstants;
@@ -44,6 +43,7 @@ import net.di2e.ecdr.search.transform.atom.security.impl.ConfigurationSecurityMa
 import net.di2e.ecdr.search.transform.atom.security.impl.MetacardSecurityMarkingHandler;
 import net.di2e.ecdr.search.transform.atom.security.impl.XmlMetadataSecurityMarkingHandler;
 import net.di2e.ecdr.search.transform.geo.formatter.CompositeGeometry;
+
 import org.apache.abdera.Abdera;
 import org.apache.abdera.ext.geo.Position;
 import org.apache.abdera.ext.opensearch.OpenSearchConstants;
@@ -59,20 +59,23 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.activation.MimeType;
-import javax.activation.MimeTypeParseException;
-import javax.xml.namespace.QName;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+import ddf.action.Action;
+import ddf.action.ActionProvider;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.BinaryContentImpl;
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.MetacardTransformer;
+import ddf.catalog.transform.QueryResponseTransformer;
 
 public abstract class AbstractAtomTransformer implements MetacardTransformer, QueryResponseTransformer {
 
@@ -80,8 +83,6 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
 
     private static final Logger LOGGER = LoggerFactory.getLogger( AbstractAtomTransformer.class );
     private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.dateTime();
-
-    
 
     private ActionProvider viewMetacardActionProvider = null;
     private ActionProvider resourceActionProvider = null;
@@ -99,8 +100,8 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
 
     List<SecurityMarkingHandler> securityHandlers = null;
 
-    public AbstractAtomTransformer( ConfigurationWatcherImpl config, ActionProvider viewMetacard, ActionProvider metadataProvider, ActionProvider resourceProvider, ActionProvider thumbnailProvider,
-        MimeType thumbnailMime, MimeType viewMime, List<SecurityConfiguration> securityConfigs ) {
+    public AbstractAtomTransformer( ConfigurationWatcherImpl config, ActionProvider viewMetacard, ActionProvider metadataProvider, ActionProvider resourceProvider,
+            ActionProvider thumbnailProvider, MimeType thumbnailMime, MimeType viewMime, List<SecurityConfiguration> securityConfigs ) {
         if ( viewMime == null || thumbnailMime == null ) {
             throw new IllegalArgumentException( "MimeType parameters to constructor cannot be null" );
         }
@@ -129,7 +130,9 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
     /**
      * Specifies if GML encoding should be used for location data.
      *
-     * @param shouldUseGMLEncoding true (default) will return locations as GeoRSS-GML; false will return locations as GeoRSS-Simple
+     * @param shouldUseGMLEncoding
+     *            true (default) will return locations as GeoRSS-GML; false will
+     *            return locations as GeoRSS-Simple
      */
     public void setUseGMLEncoding( boolean shouldUseGMLEncoding ) {
         defaultToUseGMLEncoding = shouldUseGMLEncoding;
@@ -140,6 +143,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
         if ( properties == null ) {
             properties = new HashMap<String, Serializable>();
         }
+
         ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
         Feed feed = null;
         // The Adbera.getInstance.newFeed() spins up a new thread so must do
@@ -153,8 +157,6 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
 
         feed.declareNS( AtomResponseConstants.CDRB_NAMESPACE, AtomResponseConstants.CDRB_NAMESPACE_PREFIX );
         feed.declareNS( AtomResponseConstants.CDRS_EXT_NAMESPACE, AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX );
-
-        
 
         feed.newId();
         setFeedTitle( feed, properties );
@@ -185,13 +187,13 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
 
             if ( relevance != null ) {
                 Element relevanceElement = entry.addExtension( new QName( AtomResponseConstants.RELEVANCE_NAMESPACE, AtomResponseConstants.RELEVANCE_ELEMENT,
-                    AtomResponseConstants.RELEVANCE_NAMESPACE_PREFIX ) );
+                        AtomResponseConstants.RELEVANCE_NAMESPACE_PREFIX ) );
                 relevanceElement.setText( String.valueOf( relevance ) );
             }
             Double distance = result.getDistanceInMeters();
             if ( distance != null ) {
                 Element distanceElement = entry.addExtension( new QName( AtomResponseConstants.CDRS_EXT_NAMESPACE, AtomResponseConstants.DISTANCE_ELEMENT,
-                    AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX ) );
+                        AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX ) );
                 distanceElement.setText( String.valueOf( distance ) );
             }
             feed.addEntry( entry );
@@ -264,7 +266,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
                         Integer totalResultsReturned = (Integer) sourceProperties.get( "total-results-returned" );
                         if ( totalResultsReturned != null ) {
                             sourceStatus.addSimpleExtension( AtomResponseConstants.CDRB_NAMESPACE, "resultsRetrieved", AtomResponseConstants.CDRB_NAMESPACE_PREFIX,
-                                String.valueOf( totalResultsReturned ) );
+                                    String.valueOf( totalResultsReturned ) );
                         }
                     } else {
                         sourceStatus.addSimpleExtension( AtomResponseConstants.CDRB_NAMESPACE, "resultsRetrieved", AtomResponseConstants.CDRB_NAMESPACE_PREFIX, String.valueOf( results.size() ) );
@@ -318,16 +320,16 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
                         Integer totalResultsReturned = (Integer) sourceProperties.get( "total-results-returned" );
                         if ( totalResultsReturned != null ) {
                             sourceStatus.addSimpleExtension( AtomResponseConstants.CDRB_NAMESPACE, "resultsRetrieved", AtomResponseConstants.CDRB_NAMESPACE_PREFIX,
-                                String.valueOf( totalResultsReturned ) );
+                                    String.valueOf( totalResultsReturned ) );
                         }
                         sourceStatus.addSimpleExtension( AtomResponseConstants.CDRB_NAMESPACE, "status", AtomResponseConstants.CDRB_NAMESPACE_PREFIX, "complete" );
-                        sourceStatus
-                            .addSimpleExtension( AtomResponseConstants.CDRS_EXT_NAMESPACE, "statusMessage", AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX, "Search complete with no errors" );
+                        sourceStatus.addSimpleExtension( AtomResponseConstants.CDRS_EXT_NAMESPACE, "statusMessage", AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX,
+                                "Search complete with no errors" );
                     } else {
                         sourceStatus.addSimpleExtension( AtomResponseConstants.CDRB_NAMESPACE, "resultsRetrieved", AtomResponseConstants.CDRB_NAMESPACE_PREFIX, "0" );
                         sourceStatus.addSimpleExtension( AtomResponseConstants.CDRB_NAMESPACE, "status", AtomResponseConstants.CDRB_NAMESPACE_PREFIX, "waiting" );
                         sourceStatus.addSimpleExtension( AtomResponseConstants.CDRS_EXT_NAMESPACE, "statusMessage", AtomResponseConstants.CDRS_EXT_NAMESPACE_PREFIX,
-                            "Source is still being searched, and has not returned results yet" );
+                                "Source is still being searched, and has not returned results yet" );
                     }
 
                     if ( StringUtils.isNotBlank( feedPath ) ) {
@@ -422,7 +424,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
             element.setText( sourceId );
         }
 
-        addLinksToEntry( entry, metacard, format );
+        addLinksToEntry( entry, metacard, format, properties );
 
         if ( metacard.hasLocation() ) {
             addLocation( entry, metacard, useGmlEncoding( properties ) );
@@ -431,13 +433,13 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
         Date createdDate = metacard.getCreatedDate();
         if ( createdDate != null ) {
             entry.addSimpleExtension( AtomResponseConstants.METACARD_ATOM_NAMESPACE, AtomResponseConstants.METACARD_CREATED_DATE_ELEMENT, AtomResponseConstants.METACARD_ATOM_NAMESPACE_PREFIX,
-                DATE_FORMATTER.print( createdDate.getTime() ) );
+                    DATE_FORMATTER.print( createdDate.getTime() ) );
         }
 
         Date expirationDate = metacard.getExpirationDate();
         if ( expirationDate != null ) {
             entry.addSimpleExtension( AtomResponseConstants.METACARD_ATOM_NAMESPACE, AtomResponseConstants.METADATA_EXPIRATION_DATE_ELEMENT, AtomResponseConstants.METACARD_ATOM_NAMESPACE_PREFIX,
-                DATE_FORMATTER.print( expirationDate.getTime() ) );
+                    DATE_FORMATTER.print( expirationDate.getTime() ) );
         }
 
         addEntryElements( entry, metacard, properties );
@@ -446,12 +448,16 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
     }
 
     /**
-     * This method inspects the properties to determine if there is a property that specifies the GeoRSS format. If that
-     * property exists then it will use the value of that property to determine whether to use simple or gml format.
-     * Otherwise it will return the default global property for using GML or Simple
+     * This method inspects the properties to determine if there is a property
+     * that specifies the GeoRSS format. If that property exists then it will
+     * use the value of that property to determine whether to use simple or gml
+     * format. Otherwise it will return the default global property for using
+     * GML or Simple
      *
-     * @param properties that were passed into the transformer
-     * @return true if GML encoding for GeoRSS should be used, false would mean to use simple encoding
+     * @param properties
+     *            that were passed into the transformer
+     * @return true if GML encoding for GeoRSS should be used, false would mean
+     *         to use simple encoding
      */
     protected boolean useGmlEncoding( Map<String, Serializable> properties ) {
         String format = (String) properties.get( SearchConstants.GEORSS_RESULT_FORMAT_PARAMETER );
@@ -466,9 +472,8 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
         return useGml;
     }
 
-    protected void addLinksToEntry( Entry entry, CDRMetacard metacard, String format ) {
+    protected void addLinksToEntry( Entry entry, CDRMetacard metacard, String format, Map<String, Serializable> properties ) {
         if ( metacard.hasThumbnail() ) {
-            URI thumbnailURI = metacard.getThumbnailURL();
 
             if ( thumbnailActionProvider != null ) {
                 Action action = thumbnailActionProvider.getAction( metacard );
@@ -494,8 +499,11 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
         if ( viewMetacardActionProvider != null ) {
             Action action = viewMetacardActionProvider.getAction( metacard );
             if ( action != null && action.getUrl() != null ) {
-                entry.addLink( action.getUrl().toString() + "?transform=" + (format == null ? CDR_ATOM_TRANSFORMER_ID : format), Link.REL_SELF, AtomResponseConstants.ATOM_MIME_TYPE,
-                    "View Atom Entry", null, -1 );
+                String transformFormat = (String) properties.get( SearchConstants.METACARD_TRANSFORMER_NAME );
+                if ( StringUtils.isBlank( transformFormat ) ) {
+                    transformFormat = format == null ? CDR_ATOM_TRANSFORMER_ID : format;
+                }
+                entry.addLink( action.getUrl().toString() + "?transform=" + transformFormat, Link.REL_SELF, AtomResponseConstants.ATOM_MIME_TYPE, "View Atom Entry", null, -1 );
                 entry.addLink( action.getUrl().toString(), Link.REL_RELATED, "text/xml", action.getTitle(), null, -1 );
             }
         }
@@ -559,7 +567,7 @@ public abstract class AbstractAtomTransformer implements MetacardTransformer, Qu
 
     protected void setFeedSecurity( Feed feed, String format ) {
         SecurityConfiguration securityConfiguration = null;
-        if (StringUtils.isNotBlank( format )) {
+        if ( StringUtils.isNotBlank( format ) ) {
             securityConfiguration = getConfigurationFromFormat( format );
         }
 

--- a/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AtomTransformerWithPayload.java
+++ b/transformer/cdr-atom-result-xformer/src/main/java/net/di2e/ecdr/search/transform/atom/AtomTransformerWithPayload.java
@@ -46,6 +46,8 @@ import ddf.catalog.transform.MetacardTransformer;
 
 public class AtomTransformerWithPayload extends AtomTransformer {
 
+    private static final String TRANSFORMER_ID = "atom-with-payload";
+
     private static final Logger LOGGER = LoggerFactory.getLogger( AtomTransformerWithPayload.class );
 
     private Map<String, MetacardTransformer> metacardTransformerMap = null;
@@ -133,8 +135,12 @@ public class AtomTransformerWithPayload extends AtomTransformer {
      */
     public void metacardTransformerAdded( MetacardTransformer transformer, Map<String, Object> map ) {
         String id = (String) map.get( Constants.SERVICE_ID );
-        metacardTransformerMap.put( id, transformer );
-        LOGGER.debug( "Adding MetacardTransformer with id [{}] to transformer map.", id );
+        // We need to filter out this transformer from being included in the
+        // Metacard Transformers used to produce metadata records
+        if ( !StringUtils.equalsIgnoreCase( id, TRANSFORMER_ID ) ) {
+            metacardTransformerMap.put( id, transformer );
+            LOGGER.debug( "Adding MetacardTransformer with id [{}] to transformer map.", id );
+        }
     }
 
     /**

--- a/transformer/cdr-transformer-mapper/src/main/java/net/di2e/ecdr/search/transform/mapper/TransformIdMapperImpl.java
+++ b/transformer/cdr-transformer-mapper/src/main/java/net/di2e/ecdr/search/transform/mapper/TransformIdMapperImpl.java
@@ -52,6 +52,8 @@ public class TransformIdMapperImpl implements TransformIdMapper {
         metacardTransformFormats.put( CDR_ATOM_DDMS20_TRANSFORM_ID, DDMS20_METACARD_TRANSFORM );
         metacardTransformFormats.put( CDR_ATOM_DDMS41_TRANSFORM_ID, DDMS41_METACARD_TRANSFORM );
         metacardTransformFormats.put( CDR_ATOM_DDMS50_TRANSFORM_ID, DDMS50_METACARD_TRANSFORM );
+        metacardTransformFormats.put( CDR_ATOM_DDMS_TRANSFORM_ID, CDR_ATOM_WITH_PAYLOAD_TRANSFORM_ID );
+        metacardTransformFormats.put( DEFAULT_DDF_ATOM_TRANSFORM_ID, CDR_ATOM_TRANSFORM_ID );
     }
 
     /**

--- a/transformer/cdr-transformer-mapper/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/transformer/cdr-transformer-mapper/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -27,7 +27,7 @@
         
         <AD name="Metadata/Metacard Transformer Mappings" id="metacardTransformValues" required="true" type="String" cardinality="50"
             description="Maps the external value to the internal value used to lookup the transform. Use the format extenral-value=internal-value"
-            default="atom-ddms-2.0=ddms20, atom-ddms-4.1=ddms41, atom-ddms-5.0=ddms50" />
+            default="atom=cdr-atom, atom-ddms=atom-with-payload, atom-ddms-2.0=ddms20, atom-ddms-4.1=ddms41, atom-ddms-5.0=ddms50" />
 
     </OCD>
 

--- a/transformer/cdr-transformer-mapper/src/test/java/net/di2e/ecdr/search/transform/mapper/TransformIdMapperTest.java
+++ b/transformer/cdr-transformer-mapper/src/test/java/net/di2e/ecdr/search/transform/mapper/TransformIdMapperTest.java
@@ -32,10 +32,10 @@ public class TransformIdMapperTest {
         Assert.assertEquals( "atom-with-payload", mapper.getQueryResponseTransformValue( "atom-ddms-4.1" ) );
         Assert.assertEquals( "atom-with-payload", mapper.getQueryResponseTransformValue( "atom-ddms-5.0" ) );
 
-        Assert.assertEquals( null, mapper.getMetacardTransformValue( "atom" ) );
+        Assert.assertEquals( "cdr-atom", mapper.getMetacardTransformValue( "atom" ) );
         Assert.assertEquals( null, mapper.getMetacardTransformValue( "ddf-atom" ) );
         Assert.assertEquals( null, mapper.getMetacardTransformValue( "cdr-atom" ) );
-        Assert.assertEquals( null, mapper.getMetacardTransformValue( "atom-ddms" ) );
+        Assert.assertEquals( "atom-with-payload", mapper.getMetacardTransformValue( "atom-ddms" ) );
         Assert.assertEquals( "ddms20", mapper.getMetacardTransformValue( "atom-ddms-2.0" ) );
         Assert.assertEquals( "ddms41", mapper.getMetacardTransformValue( "atom-ddms-4.1" ) );
         Assert.assertEquals( "ddms50", mapper.getMetacardTransformValue( "atom-ddms-5.0" ) );


### PR DESCRIPTION
… to include in the atom links.  For example it will include transform=ddms41 for the Metacard Transformer instead of format=atom-ddms-4.1 (this does not exist).  Also had to filter out the atom-with-payload form metacard transform mapper as it would embed an atom entry within an atom entry when it was called as a query response transformer.

FYI @mrmateo

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/57)
<!-- Reviewable:end -->
