### PR TITLE
ECDR-115 added in the setting of the sourceId for all metacards that …

### DIFF
--- a/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/OpenSearchSource.java
+++ b/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/OpenSearchSource.java
@@ -80,6 +80,7 @@ public class OpenSearchSource extends AbstractCDRSource {
         LOGGER.debug( "Checking cache for Result with id [{}].", id );
         Metacard metacard = metacardCache.get( id );
         if ( metacard != null ) {
+            metacard.setSourceId( getId() );
             LOGGER.debug( "Cache hit found for id [{}], returning response", id );
             sourceResponse = new SourceResponseImpl( queryRequest, Arrays.asList( (Result) new ResultImpl( metacard ) ), 1L );
         } else {


### PR DESCRIPTION
…are returned from the ECDR Source cache, since it is not persisted through serialization

FYI @mrmateo just going to merge this one in since it was a one-liner

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/60)
<!-- Reviewable:end -->
