### PR TITLE
ECDR-143: Added null check to prevent framework exceptions.

### DIFF
--- a/libs/cdr-rest-search-commons/src/main/java/net/di2e/ecdr/commons/util/DateTypeMap.java
+++ b/libs/cdr-rest-search-commons/src/main/java/net/di2e/ecdr/commons/util/DateTypeMap.java
@@ -47,13 +47,17 @@ public class DateTypeMap {
     }
 
     public void addConfiguration( ServiceReference<DateTypeConfiguration> ref ) {
-        DateTypeConfiguration config = context.getService( ref );
-        dateMap.put( config.getCDRDateType(), config );
+        if (ref != null) {
+            DateTypeConfiguration config = context.getService( ref );
+            dateMap.put( config.getCDRDateType(), config );
+        }
     }
 
     public void removeConfiguration( ServiceReference<DateTypeConfiguration> ref ) {
-        DateTypeConfiguration config = context.getService( ref );
-        dateMap.remove( config.getCDRDateType() );
+        if (ref != null) {
+            DateTypeConfiguration config = context.getService( ref );
+            dateMap.remove( config.getCDRDateType() );
+        }
     }
 
     public Set<String> keySet() {


### PR DESCRIPTION
fyi @jvettraino 
I didn’t see any specific race condition going on but it looks like on registration the framework is sending a null servicereference which then causes the bundlecontext to throw an exception when doing a lookup. This is a simple fix that will ignore those null servicereferences.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/82)
<!-- Reviewable:end -->
