### PR TITLE
ECDR-152 - Added joda-convert to feature file

### DIFF
--- a/apps/cdr-app/src/main/resources/features.xml
+++ b/apps/cdr-app/src/main/resources/features.xml
@@ -81,6 +81,7 @@
     
     <feature name="cdr-common" install="manual" version="${project.version}" description="CDR Common bundles.">
         <bundle>mvn:joda-time/joda-time/${joda.time.version}</bundle>
+        <bundle>mvn:org.joda/joda-convert/${joda.convert.version}</bundle>
         <bundle>mvn:net.di2e.ecdr.api/cdr-api/${project.version}</bundle>
         <bundle>mvn:net.di2e.ecdr.libs/cdr-libs-cache/${project.version}</bundle>
         <bundle>mvn:net.di2e.ecdr.libs/cdr-rest-search-commons/${project.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <ddf.compression.version>2.6.0</ddf.compression.version>
         <ddf.registry.version>0.1.0</ddf.registry.version>
         <joda.time.version>2.2</joda.time.version>
+        <joda.convert.version>1.7</joda.convert.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
DDF 2.6.x doesn't come with this exposed (other versions like DDF 2.7.x do), so we need to specifically include this for backwards compatibility with DDF 2.6.x

FYI @mrmateo

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/89)
<!-- Reviewable:end -->
