### PR TITLE
ECDR-150 Final commit resolving the SAML cookie issue on DDF 2.7.x in the CDR Federated Source

### DIFF
--- a/source/cdr-rest-source/pom.xml
+++ b/source/cdr-rest-source/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -31,6 +32,16 @@
     <packaging>bundle</packaging>
 
     <dependencies>
+    
+        <!-- Version is to align with the ddf-security-common 2.7.x which depends 
+        on CXF 3.0.4 (however we want to remain compatible at compile and runtime to CXF 2.7.x)-->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <version>3.0.4</version>
+            <scope>provided</scope>
+        </dependency>
+        
         <dependency>
             <groupId>net.di2e.ecdr.libs</groupId>
             <artifactId>cdr-rest-search-commons</artifactId>
@@ -41,6 +52,14 @@
             <groupId>net.di2e.ecdr.transformer</groupId>
             <artifactId>cdr-atom-result-xformer</artifactId>
             <version>${project.version}</version>
+          <!-- Need to exclude this so it doesn't conflict with Jetty.  If we don't we get the following error
+          java.lang.SecurityException: class "javax.servlet.ServletRegistration"'s signer information does not match  -->
+            <exclusions>
+                <exclusion>
+                    <artifactId>servlet-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -57,6 +76,13 @@
             <groupId>ddf.security</groupId>
             <artifactId>ddf-security-common</artifactId>
             <version>2.7.1</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>servlet-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -66,10 +92,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-bundle</artifactId>
+            <artifactId>commons-collections</artifactId>
+            <groupId>commons-collections</groupId>
+            <version>3.2.1</version>
         </dependency>
-
+        
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
@@ -85,20 +112,6 @@
         </dependency>
 
         <!-- Two-way SSL Testing -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>8.1.14.v20131031</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
@@ -135,6 +148,8 @@
                             net.di2e.ecdr.commons,
                             org.apache.cxf.*;version="[2.7.0, 4.0)",
                             org.apache.ws.security.*;resolution:=optional,
+                            org.apache.wss4j.common.ext.*;resolution:=optional,
+                            org.apache.wss4j.*;resolution:=optional,
                             *
                         </Import-Package>
                         <Private-Package>

--- a/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/CDROpenSearchSource.java
+++ b/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/CDROpenSearchSource.java
@@ -501,7 +501,7 @@ public class CDROpenSearchSource extends CDRSourceConfiguration implements Feder
                 Serializable property = requestProperties.get( SecurityConstants.SECURITY_SUBJECT );
                 if ( property instanceof Subject ) {
                     Subject subject = (Subject) property;
-                    RestSecurity.setSubjectOnClient( subject, client );
+                    RestSecurity.setUnsecuredSubjectOnClient( subject, client );
                 }
             }
         }

--- a/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/CDRSourceConfiguration.java
+++ b/source/cdr-rest-source/src/main/java/net/di2e/ecdr/source/rest/CDRSourceConfiguration.java
@@ -15,6 +15,7 @@
  */
 package net.di2e.ecdr.source.rest;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +47,6 @@ import ddf.catalog.util.impl.MaskableImpl;
 public abstract class CDRSourceConfiguration extends MaskableImpl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger( CDRSourceConfiguration.class );
-
 
     public enum PingMethod {
         GET, HEAD, NONE
@@ -116,8 +116,8 @@ public abstract class CDRSourceConfiguration extends MaskableImpl {
         hardcodedParamMap.put( SearchConstants.QUERYLANGUAGE_PARAMETER, SearchConstants.CDR_CQL_QUERY_LANGUAGE );
 
         sortMap = new HashMap<>();
-        sortMap = SearchUtils.convertToMap( Metacard.TITLE + "=title," + Metacard.MODIFIED + "=updated," + Metacard.EFFECTIVE + "=published," + Metacard.CREATED + "=created,"
-                + Result.RELEVANCE + "=score," + Result.DISTANCE + "=distance" );
+        sortMap = SearchUtils.convertToMap( Metacard.TITLE + "=title," + Metacard.MODIFIED + "=updated," + Metacard.EFFECTIVE + "=published," + Metacard.CREATED + "=created," + Result.RELEVANCE
+                + "=score," + Result.DISTANCE + "=distance" );
 
         parameterMap = new HashMap<>();
         parameterMap.putAll( parameterMatchMap );
@@ -199,7 +199,7 @@ public abstract class CDRSourceConfiguration extends MaskableImpl {
             conduit.getClient().setConnectionTimeout( connectionTimeout );
             TLSUtil.setTLSOptions( getPingClient(), getDisableCNCheck() );
             // conduit.setTlsClientParameters( TLSUtil.getTlsClientParameters( disableCNCheck ) );
-            
+
         } else {
             LOGGER.debug( "ConfigUpdate: Updating the ping (site availability check) endpoint url to [null], will not be performing ping checks" );
         }
@@ -360,8 +360,20 @@ public abstract class CDRSourceConfiguration extends MaskableImpl {
         if ( disableCNCheck != disableCheck ) {
             LOGGER.debug( "ConfigUpdate: Updating the Disable CN Check (for certificates) boolean value from [{}] to [{}]", disableCNCheck, disableCheck );
             disableCNCheck = disableCheck;
-            setPingUrl( getPingClient().getCurrentURI().toString() );
-            setUrl( getRestClient().getCurrentURI().toString() );
+            WebClient client = getPingClient();
+            if ( client != null ) {
+                URI pingUri = client.getCurrentURI();
+                if ( pingUri != null ) {
+                    setPingUrl( pingUri.toString() );
+                }
+            }
+            client = getRestClient();
+            if ( client != null ) {
+                URI pingUri = client.getCurrentURI();
+                if ( pingUri != null ) {
+                    setUrl( pingUri.toString() );
+                }
+            }
         }
     }
 
@@ -462,7 +474,5 @@ public abstract class CDRSourceConfiguration extends MaskableImpl {
             metacardCache.destroy();
         }
     }
-
-
 
 }

--- a/source/cdr-rest-source/src/test/java/net/di2e/ecdr/source/rest/RestAssertionTest.java
+++ b/source/cdr-rest-source/src/test/java/net/di2e/ecdr/source/rest/RestAssertionTest.java
@@ -15,21 +15,16 @@
  */
 package net.di2e.ecdr.source.rest;
 
-import java.io.InputStream;
-
-import org.apache.cxf.common.util.Base64Utility;
-import org.apache.cxf.helpers.IOUtils;
-import org.apache.cxf.rs.security.saml.DeflateEncoderDecoder;
 
 public class RestAssertionTest {
 
     public static final String COOKIE = "7VhZb6tKEn73r7B8HiMH8I6VZKZZTHCCF8Dry4ilWcxm02DAv/42+Ngn8SRnuXM1ZzQzUqSoq6u/rq+quqrwA9ICvzUECME4caOwLnKPjX9AQ6MGptZrGlqXbHZoq9/U2wZsdsyORbbbfbprUY26iFAKxRAlWpg8Nlok1W2SvWarq5LUsN0Ztgf33X5326gvYYwwNFa5Jxv1PPBDNKyufWykcTiMNOSiYagFEA0TY6gA6XWINYfaxabLmRw9Npwk2Q8JIsuy+6x9H8U20SJJilhLr4rhwED7puv+WLnpVsYbEJ9C7jAp9vCxceMQFQsbTw9nacU4fvIjQ/OdCCUPxDv5g4mGimuHWpLG8Ksh5mdGkwRJE1jHRK79pXE9C00xtKJqyWphFLr4KveklaZIMHEisw58O4rdxAk+JUiRJXAT5kbToDrhlwbx3rSfBHpnYYy0JnI06iuWDC0YQ+y6+kIWHxtffi5lqqNqrIXIiuIAvV/+mj0wPEI/2kOziS60vpr284AfeOrpARpDMTT8FLlHOCmTcq8ZENVnMbTc/NVFONVzdEkzaPxSEIi35t0sz97gXBui5M8E6E1wziBLzU/hU3+mdmcMdzqtcrfYp2nSusvFDReMOfBYGfBWuRJcQ3te3iTlNYnOJ57Xrmu27mIO9jIpmW7WLyrtwLR3CKebVr5dK1yrRZ34xetxPGofHGtriQezE1Oeq2Y9OoAzeqrFc1bh0pVmTYFBB+1VngIPWv2uzvtdk+/DOzIkza1sid6eMIFBhcVJNFbOKojWA87gn2fsQUB3xzt+ZrnERu0dpDU3OchFsaUk/ZRQUHwObcp+vNJ5Y39J6QUWV3rrLklzWqJdF2xZBiz8ChP4JIkix59YFoSFDTKRAbY4BuLJ6Iw2sbinAwmQAqscBEXU29ycZ5j5AkjPRs6ewJixJ0sGbFTgL1VpjrIaO99wy/lc5PDeasdLEogEQC141s44mZcFaZ5lrF3pvHJgwm/Xm1xQwfoMJEk8j7Vcht+uqGNNHI2Pentuz0k+x5F1Gds7OJ4r0BnJsHN+NVrJ3jYsdeTdZsH4UBglhpD7rwFdbE8AjjIyn3B8IamgqEnqoiOpjlYJ1bPwIpNEgSvN/2q9wGfj5eLEv0rAO1sP8NYyynkVzEpLawwwJJY3j3pL7m5Xo+INrZeSlsxvco4DL2daCLtQ9s0dr0gMqABBlo11gd5tVnlU09sTUlLmmWhvxi/RVnSOxgTMPWbkLJHemji6gCVtGWzXjqOvGbRVukcjMDJ7O8i4+dszPFNj5oCzNyTAlMbY99inkC0mW51Vt3vneW4xXXswim3mQMmb07LvesuM2C8F7zSw87bfBjSNBqsEdAIZwJreC8mjKtPFhJlCb9UJN1OXnx4InI8uYcUi5Z3Iuc4/U6hliN1wxKSJpnPt2UbIF0qq7XXjDij9u5nnx2RN5cSOJJ9mM89T953Mn8pzQuux1hJNYiJY2q8t1gI29hAQdvbWw/Q254DIpMoAMQMcCBnbtx3PZmrO0WEBzgvB2Wxkj1bEkTxaUPJY9Qx7MVoqC55WZYWZqV6+lRiydLrJ2fMVwyiA7s5FqWDAs4xMUu6gWp9tMzEcxYgDVhmxZ0XiBQ6sbEZ1lhJct7OYPfZ8C446fbY4egoD6XwH7EpX5vkygW35HKzaZ9G6idToHCgeJPJi37dAviD43phrveyIO1ZdHdIB7+c1qq2Qah6Jh2PbliJmRUKnOPEvu7FL6jplL/JpP6SUYMor+y7i2ztBDR1SSDZLkmtR9AlX0pAmDZNwA8DXHC8c+1pRmKSy24faKz1emIN0k49hXgzUcQtJDhLAtsdL6pa1VDog+2szzXco4E6k4yvCkjxXm9sKchWeawzxtvq8q06XiUNJ9R00ksuybEgiVx/hfqEln49P1D1VSVyzaVWqwzREe2hgM6DZqJco8xTPFXgZX3uLkVv3Gm52Dqz6C0pQ40kzAze8TDnny28sY6PQcssryuHx3Le+P9YZwVCHWgzjqiF+yBJjmm4JiOqTKGEg5gA/GzD7eMDEStNwGgMrKem81WsNyW96F3iQmm7Z32Tc92LXKC+63XoqfYKwU66j3nBA020CD4VHF48DhAKNFLfmQo08GCpn6d8yZPoXSlekW8G7W4lbwt8MSZxQSXDOBDBM6tXyx6P2u9MYNIF58pGM9fFwjfv803fnb2NolHpYPMP/sig2Z3GU4DhBs5pa9lGcfGP3AfpHm++FV4ZXKxPsHD1N4Oc7VfpesxZVkzy6x2MQirR9lboZKqejLoH/XBND4DgRmIobICKOfHh+AD96Q5UL8J2l9KNX9E92VQPFmw+JHH/l4K3QbjzZcZTur8TfHfgVmHev8c/DBFqo2TD+14GOLsz+CpwM6gbOfRyaz7BuxX9tUpxLZSkrC+K/Pz3K77wiiFL0e+j/njfxf9L/M6S/V7b+y1/276OOdV1fM80YIvSbiP8d5lqw9+G9EQW/xwkordj8xwee+Hz6IW5+kHz6Aw==";
 
     public static void main( String[] args ) throws Exception {
-        byte[] cv = Base64Utility.decode( COOKIE );
-        DeflateEncoderDecoder decoder = new DeflateEncoderDecoder();
-        InputStream is = decoder.inflateToken( cv );
-        System.out.println( IOUtils.toString( is ) );
+        // byte[] cv = Base64Utility.decode( COOKIE );
+        // DeflateEncoderDecoder decoder = new DeflateEncoderDecoder();
+        // InputStream is = decoder.inflateToken( cv );
+        // System.out.println( IOUtils.toString( is ) );
     }
 
 }


### PR DESCRIPTION
updated the dependencies so the tests would work, also put in defensive logic for the WebClients getting set by the Config Admin (randomly) to prevent a NPE, and updated the security logic call to work with both HTTP and HTTPS

FYI @mrmateo 