### PR TITLE
ECDR-155 add in logic to completely shut down the Hazelcast cache.

### DIFF
--- a/libs/cdr-libs-cache/src/main/java/net/di2e/ecdr/libs/cache/impl/MetacardJCacheManager.java
+++ b/libs/cdr-libs-cache/src/main/java/net/di2e/ecdr/libs/cache/impl/MetacardJCacheManager.java
@@ -106,6 +106,7 @@ public class MetacardJCacheManager implements net.di2e.ecdr.api.cache.CacheManag
         }
         cacheManager.close();
         cachingProvider.close();
+        Hazelcast.shutdownAll();
     }
 
     @Override


### PR DESCRIPTION
FYI simple fix @mrmateo 
I tested this out and it seemed to do the trick and didn't impact any other HAzelcast cache instances.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/di2e/ecdr/92)
<!-- Reviewable:end -->
